### PR TITLE
Use Steam Linux Runtime 3.0

### DIFF
--- a/deps/7th Heaven.sh
+++ b/deps/7th Heaven.sh
@@ -1,22 +1,23 @@
 #!/bin/bash
-export LD_LIBRARY_PATH="$PROTON_DIR/dist/lib:$PROTON_DIR/dist/lib64:$LD_LIBRARY_PATH"
 export STEAM_COMPAT_DATA_PATH="WINEPATH"
 export STEAM_COMPAT_CLIENT_INSTALL_PATH="${HOME}/.local/share/Steam"
 export STEAM_RUNTIME=0
 
-PROTON_HOME="${HOME}/.local/share/Steam/steamapps/common/Proton 8.0"
-PROTON_SD="/run/media/mmcblk0p1/steamapps/common/Proton 8.0"
-SOLDIER_HOME="${HOME}/.local/share/Steam/steamapps/common/SteamLinuxRuntime_soldier"
-SOLDIER_SD="/run/media/mmcblk0p1/steamapps/common/SteamLinuxRuntime_soldier"
+REAPER="${HOME}/.local/share/Steam/ubuntu12_32/reaper"
+SNIPER_HOME="${HOME}/.local/share/Steam/steamapps/common/SteamLinuxRuntime_sniper/_v2-entry-point"
+SNIPER_SD="/run/media/mmcblk0p1/steamapps/common/SteamLinuxRuntime_sniper/_v2-entry-point"
+PROTON_HOME="${HOME}/.local/share/Steam/steamapps/common/Proton 8.0/proton"
+PROTON_SD="/run/media/mmcblk0p1/steamapps/common/Proton 8.0/proton"
 
-[ -d "$PROTON_HOME" ] && PROTON_DIR="$PROTON_HOME" || \
-{ [ -d "$PROTON_SD" ] && PROTON_DIR="$PROTON_SD" || \
+[ ! -f "$REAPER" ] && { echo "Reaper not found!"; exit 1; }
+
+[ -f "$SNIPER_HOME" ] && SNIPER="$SNIPER_HOME" || \
+{ [ -f "$SNIPER_SD" ] && SNIPER="$SNIPER_SD" || \
+{ echo "Sniper not found!"; exit 1; }; }
+
+[ -f "$PROTON_HOME" ] && PROTON="$PROTON_HOME" || \
+{ [ -f "$PROTON_SD" ] && PROTON="$PROTON_SD" || \
 { echo "Proton not found!"; exit 1; }; }
 
-[ -d "$SOLDIER_HOME" ] && SOLDIER_DIR="$SOLDIER_HOME" || \
-{ [ -d "$SOLDIER_SD" ] && SOLDIER_DIR="$SOLDIER_SD" || \
-{ echo "Soldier not found!"; exit 1; }; }
-
-${HOME}/.local/share/Steam/ubuntu12_32/reaper SteamLaunch AppId=39140 -- \
-"$SOLDIER_DIR/_v2-entry-point" --verb=waitforexitandrun -- \
-"$PROTON_DIR/proton" waitforexitandrun "7th Heaven.exe" $*
+"$REAPER" SteamLaunch AppId=39140 -- "$SNIPER" -- "$PROTON" waitforexitandrun \
+"7th Heaven.exe" $*

--- a/deps/7th Heaven.sh
+++ b/deps/7th Heaven.sh
@@ -9,15 +9,15 @@ SNIPER_SD="/run/media/mmcblk0p1/steamapps/common/SteamLinuxRuntime_sniper/_v2-en
 PROTON_HOME="${HOME}/.local/share/Steam/steamapps/common/Proton 8.0/proton"
 PROTON_SD="/run/media/mmcblk0p1/steamapps/common/Proton 8.0/proton"
 
-[ ! -f "$REAPER" ] && { echo "Reaper not found!"; exit 1; }
+[ ! -f "$REAPER" ] && { kdialog --error  "Reaper not found!"; exit 1; }
 
 [ -f "$SNIPER_HOME" ] && SNIPER="$SNIPER_HOME" || \
 { [ -f "$SNIPER_SD" ] && SNIPER="$SNIPER_SD" || \
-{ echo "Sniper not found!"; exit 1; }; }
+{ kdialog --error  "Sniper not found!"; exit 1; }; }
 
 [ -f "$PROTON_HOME" ] && PROTON="$PROTON_HOME" || \
 { [ -f "$PROTON_SD" ] && PROTON="$PROTON_SD" || \
-{ echo "Proton not found!"; exit 1; }; }
+{ kdialog --error  "Proton not found!"; exit 1; }; }
 
 "$REAPER" SteamLaunch AppId=39140 -- "$SNIPER" -- "$PROTON" waitforexitandrun \
 "7th Heaven.exe" $*

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ FF7_DIR=$(if [ -d "${HOME}/.local/share/Steam/steamapps/common/FINAL FANTASY VII
 [ ! -d "temp" ] && mkdir temp
 
 echo "########################################################################"
-echo "#                             7thDeck v1.01                            #"
+echo "#                             7thDeck v1.1                             #"
 echo "########################################################################"
 echo "#    This script will:                                                 #"
 echo "#    1. Install protontricks from the Discover store                   #"


### PR DESCRIPTION
I mistakenly thought that Steam Linux Runtime 3.0 was new in SteamOS 3.5 when I initially wrote this. As it turns out, it's been around since 2021 and is the wrapper used in Proton 8. If there are issues with this runtime we can roll it back, but I don't expect there will be any.

Also updated to use KDialog boxes for errors with the wrapper script so that it doesn't have to be run from a terminal to find out if the runtimes are not where we expect them to be.