### PR TITLE
Accounting for Protontricks Edge Cases

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -79,8 +79,7 @@ echo
 # Install protontricks and apply patches
 echo "Installing Protontricks..."
 flatpak --system install com.github.Matoking.protontricks -y
-flatpak override --user --filesystem=/home/ com.github.Matoking.protontricks
-flatpak override --user --filesystem=/run/media/mmcblk0p1 com.github.Matoking.protontricks
+flatpak override --user --filesystem=host com.github.Matoking.protontricks
 echo
 
 # Install dependencies and patch dinput

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 shopt -s expand_aliases
-alias protontricks='flatpak run com.github.Matoking.protontricks'
+alias winetricks='flatpak --command=winetricks run com.github.Matoking.protontricks'
 WINEPATH=$(if [ -d "${HOME}/.local/share/Steam/steamapps/compatdata/39140/pfx" ]; then echo "${HOME}/.local/share/Steam/steamapps/compatdata/39140/pfx"; else echo "/run/media/mmcblk0p1/steamapps/compatdata/39140/pfx"; fi)
 FF7_DIR=$(if [ -d "${HOME}/.local/share/Steam/steamapps/common/FINAL FANTASY VII" ]; then echo "${HOME}/.local/share/Steam/steamapps/common/FINAL FANTASY VII"; else echo "/run/media/mmcblk0p1/steamapps/common/FINAL FANTASY VII"; fi)
 PROTON_HOME="${HOME}/.local/share/Steam/steamapps/common/Proton 7.0/proton"
@@ -88,7 +88,8 @@ echo "Please follow the installation prompts that appear."
 echo "The script may appear to hang here. Be patient."
 [ -f "$WINEPATH/drive_c/windows/syswow64/dinput.dll" ] && rm "$WINEPATH/drive_c/windows/syswow64/dinput.dll"
 [ -f "$WINEPATH/drive_c/windows/system32/dinput.dll" ] && rm "$WINEPATH/drive_c/windows/system32/dinput.dll"
-protontricks 39140 dinput dotnetdesktop7 &> /dev/null
+WINEPREFIX="$WINEPATH" WINESERVER="${PROTON%/proton}/dist/bin/wineserver" \
+WINE="${PROTON%/proton}/dist/bin/wine" winetricks dinput dotnetdesktop7 &> /dev/null
 echo
 
 # Download 7th Heaven from Github


### PR DESCRIPTION
I ran into a weird error with protontricks saying the Proton version wasn't supported by Protontricks after the downgrade. I could reproduce this, but not consistently, so we're going to install the dependencies using winetricks, which will install dependencies to the prefix's path and doesn't care if it knows how we're running the game. We still need the protontricks flatpak for this, so it's just a minor change to the command structure.

I also want to give protontricks access to the whole filesystem to account for any edge cases regarding the SD card mount point change in SteamOS 3.5. Future proofing or whatever.