### PR TITLE
Switch to Stable Channels

### DIFF
--- a/deps/settings.xml
+++ b/deps/settings.xml
@@ -38,7 +38,6 @@
     <GeneralOptions>CheckForUpdates</GeneralOptions>
     <GeneralOptions>OpenIrosLinksWith7H</GeneralOptions>
     <GeneralOptions>OpenModFilesWith7H</GeneralOptions>
-    <GeneralOptions>WarnAboutModCode</GeneralOptions>
   </Options>
   <IntOptions>None</IntOptions>
   <CurrentProfile>Default</CurrentProfile>

--- a/deps/settings.xml
+++ b/deps/settings.xml
@@ -29,8 +29,8 @@
   </Subscriptions>
   <LibraryLocation>REPLACE_ME</LibraryLocation>
   <FF7Exe>REPLACE_ME</FF7Exe>
-  <FFNxUpdateChannel>Canary</FFNxUpdateChannel>
-  <AppUpdateChannel>Canary</AppUpdateChannel>
+  <FFNxUpdateChannel>Stable</FFNxUpdateChannel>
+  <AppUpdateChannel>Stable</AppUpdateChannel>
   <Options>
     <GeneralOptions>AutoActiveNewMods</GeneralOptions>
     <GeneralOptions>AutoImportMods</GeneralOptions>

--- a/deps/settings.xml
+++ b/deps/settings.xml
@@ -32,6 +32,7 @@
   <FFNxUpdateChannel>Stable</FFNxUpdateChannel>
   <AppUpdateChannel>Stable</AppUpdateChannel>
   <Options>
+    <GeneralOptions>AutoSortMods</GeneralOptions>
     <GeneralOptions>AutoActiveNewMods</GeneralOptions>
     <GeneralOptions>AutoImportMods</GeneralOptions>
     <GeneralOptions>CheckForUpdates</GeneralOptions>

--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,7 @@ downloadDependency() {
   local EXTENSION=$3
   local RETURN_VARIABLE=$4
   local RELEASE_URL=$(
-    curl -s https://api.github.com/repos/"$REPO"/releases/tags/canary  \
+    curl -s https://api.github.com/repos/"$REPO"/releases  \
     | grep "browser_download_url.$EXTENSION" \
     | grep "$FILTER" \
     | head -1 \

--- a/install.sh
+++ b/install.sh
@@ -124,12 +124,6 @@ echo "Downloading 7th Heaven..."
 downloadDependency "tsunamods-codes/7th-Heaven" "" "*.zip" SEVENHEAVENZIP
 echo
 
-# Install FFNx Canary - Remove on next FFNx Stable release
-echo "Downloading FFNx..."
-downloadDependency "julianxhokaxhiu/FFNx" "FF7" "*.zip" FFNXZIP
-unzip -o $FFNXZIP -d "$FF7_DIR" &>> "7thDeck.log"
-echo
-
 # Copy dxvk.conf and settings.xml
 echo "Copying settings..."
 mkdir -p "temp/7th Heaven/mods"

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ echo "" > "7thDeck.log"
 exec > >(tee -ia "7thDeck.log") 2>&1
 
 echo "########################################################################"
-echo "#                             7thDeck v1.2                             #"
+echo "#                             7thDeck v1.3                             #"
 echo "########################################################################"
 echo "#    This script will:                                                 #"
 echo "#   1. Install protontricks from the Discover app                      #"


### PR DESCRIPTION
With the release of 7th Heaven 3.3.0.0 and FFNx 1.17.0.0, we no longer need to use canary branches for Steam Deck compatibility.

I've removed the logic for installing FFNx via the script as 7th Heaven will download the most recent stable release when launching the game.

I've also taken the liberty of disabling "WarnAboutModCode" and enabling "AutoSortMods" in the `settings.xml` to make the experience a bit smoother for Deck users.