### PR TITLE
Add mesh to tracked folders

### DIFF
--- a/deps/settings.xml
+++ b/deps/settings.xml
@@ -9,6 +9,7 @@
     <string>ambient</string>
     <string>direct</string>
     <string>lighting</string>
+    <string>mesh</string>
     <string>music</string>
     <string>sfx</string>
     <string>time</string>


### PR DESCRIPTION
Cosmos' new mods require the `widescreen` and `mesh` folders to be tracked.

We already had `widescreen` in our default `settings.xml` so I added `mesh`.