### PR TITLE
Add Limit Break compatibility to Steam Deck Auto-Config

### DIFF
--- a/deps/SteamDeckSettings/mod.xml
+++ b/deps/SteamDeckSettings/mod.xml
@@ -40,4 +40,11 @@
     <show_renderer_backend>false</show_renderer_backend>
   </FFNxConfig>
   <Variables />
+  <Compatibility>
+    <Setting>
+      <ModID>7c6a0289-ae89-411d-836a-531e78938401</ModID>
+      <TheirID>LIMITBREAK</TheirID>
+      <Require>2</Require>
+    </Setting>
+  </Compatibility>
 </ModInfo>


### PR DESCRIPTION
Automatically set Cosmos Limit Break to 16:10.

Looking into having an option added to ESUI to fix minimap woes.