### PR TITLE
Account For More Edge Cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+7thDeck.log

--- a/deps/7th Heaven.sh
+++ b/deps/7th Heaven.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 unset DOTNET_ROOT
-export PATH=$(echo "${PATH}" | sed -e 's|:/home/deck/dotnet||')
+export PATH=$(echo "${PATH}" | sed -e "s|:$HOME/dotnet||")
 export STEAM_COMPAT_APP_ID=39140
 export STEAM_COMPAT_DATA_PATH="@WINEPATH@"
 export STEAM_COMPAT_CLIENT_INSTALL_PATH=$(readlink -f "$HOME/.steam/root")

--- a/deps/7th Heaven.sh
+++ b/deps/7th Heaven.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+unset DOTNET_ROOT
+export PATH=$(echo "${PATH}" | sed -e 's|:/home/deck/dotnet||')
 export STEAM_COMPAT_APP_ID=39140
 export STEAM_COMPAT_DATA_PATH="@WINEPATH@"
 export STEAM_COMPAT_CLIENT_INSTALL_PATH=$(readlink -f "$HOME/.steam/root")

--- a/install.sh
+++ b/install.sh
@@ -57,12 +57,15 @@ if [ "$FF7_LIBRARY" = "NONE" ]; then
   exit 1
 else
   FF7_DIR="$FF7_LIBRARY/steamapps/common/FINAL FANTASY VII"
+  WINEPATH="$FF7_LIBRARY/steamapps/compatdata/39140/pfx"
   if [ $IS_STEAMOS = true ]; then
-    WINEPATH=$(if [ -d "${HOME}/.local/share/Steam/steamapps/compatdata/39140/pfx" ]; \
-    then echo "${HOME}/.local/share/Steam/steamapps/compatdata/39140/pfx"; \
-    else echo "/run/media/mmcblk0p1/steamapps/compatdata/39140/pfx"; fi)
-  else
-    WINEPATH="$FF7_LIBRARY/steamapps/compatdata/39140/pfx"
+    WINEPATH="${HOME}/.steam/steam/steamapps/compatdata/39140/pfx"
+    if [ ! -d "$WINEPATH" ]; then
+      for dir in "/run/media/deck/"*; do
+        full_path="$dir/steamapps/compatdata/39140/pfx"
+        [ -d "$full_path" ] && WINEPATH="$full_path"; break
+      done
+    fi
   fi
 fi
 echo "OK!"

--- a/install.sh
+++ b/install.sh
@@ -58,15 +58,7 @@ if [ "$FF7_LIBRARY" = "NONE" ]; then
 else
   FF7_DIR="$FF7_LIBRARY/steamapps/common/FINAL FANTASY VII"
   WINEPATH="$FF7_LIBRARY/steamapps/compatdata/39140/pfx"
-  if [ $IS_STEAMOS = true ]; then
-    WINEPATH="${HOME}/.steam/steam/steamapps/compatdata/39140/pfx"
-    if [ ! -d "$WINEPATH" ]; then
-      for dir in "/run/media/deck/"*; do
-        full_path="$dir/steamapps/compatdata/39140/pfx"
-        [ -d "$full_path" ] && WINEPATH="$full_path"; break
-      done
-    fi
-  fi
+  [ $IS_STEAMOS = true ] && WINEPATH="${HOME}/.steam/steam/steamapps/compatdata/39140/pfx"
 fi
 echo "OK!"
 echo

--- a/install.sh
+++ b/install.sh
@@ -70,7 +70,7 @@ cp ${XDG_DATA_HOME}/Steam/config/config.vdf ${XDG_DATA_HOME}/Steam/config/config
 perl -0777 -i -pe 's/"CompatToolMapping"\n\s+{/"CompatToolMapping"\n\t\t\t\t{\n\t\t\t\t\t"39140"\n\t\t\t\t\t{\n\t\t\t\t\t\t"name"\t\t"proton_7"\n\t\t\t\t\t\t"config"\t\t""\n\t\t\t\t\t\t"priority"\t\t"250"\n\t\t\t\t\t}/gs' \
 ${XDG_DATA_HOME}/Steam/config/config.vdf
 while pgrep "steam" > /dev/null; do sleep 1; done
-rm -rf "${WINEPATH%/pfx}"
+rm -rf "${WINEPATH%/pfx}"/*
 echo "Sign into the Steam account that owns FF7 if prompted."
 nohup steam steam://rungameid/39140 &> /dev/null &
 echo "Waiting for Steam..."

--- a/install.sh
+++ b/install.sh
@@ -83,6 +83,9 @@ while ! pgrep "FF7_Launcher" > /dev/null; do sleep 1; done
 pkill -9 "FF7_Launcher"
 echo
 
+# Fix infinite loop on "Verifying installed game is compatible"
+[ -L "$FF7_DIR/FINAL FANTASY VII" ] && unlink "$FF7_DIR/FINAL FANTASY VII"
+
 # Ask for install path
 promptUser "Choose an installation path for 7th Heaven. The folder must already exist."
 while true; do

--- a/install.sh
+++ b/install.sh
@@ -106,6 +106,7 @@ echo
 
 # Install 7th Heaven using EXE
 echo "Installing 7th Heaven..."
+mkdir -p "${WINEPATH}/drive_c/ProgramData" # fix vcredist install - infirit
 STEAM_COMPAT_APP_ID=39140 STEAM_COMPAT_DATA_PATH="${WINEPATH%/pfx}" \
 STEAM_COMPAT_CLIENT_INSTALL_PATH=$(readlink -f "$HOME/.steam/root") \
 "$RUNTIME" -- "$PROTON" waitforexitandrun \

--- a/install.sh
+++ b/install.sh
@@ -90,6 +90,7 @@ echo
 [ -L "$FF7_DIR/FINAL FANTASY VII" ] && unlink "$FF7_DIR/FINAL FANTASY VII"
 
 # Ask for install path
+echo "Waiting for you to select an installation path..."
 promptUser "Choose an installation path for 7th Heaven. The folder must already exist."
 while true; do
   INSTALL_PATH=$(promptDirectory "Select 7th Heaven Install Folder") || { echo "No directory selected. Exiting."; exit 1; }


### PR DESCRIPTION
A few users have been popping up with issues that most people don't have. Fixes have been applied for those scenarios

* Sometimes a symlink pointing to the current directory will exist inside the FF7 install path. I believe this is leftover from the very old Bottles installation method. Having this symlink present will cause 7th Heaven to go into an infinite loop on the "Verifying installed game is compatible" step of launching the game. **7thDeck will now remove this symlink to avoid this problem**.
* Some users will receive an error installing vcredist and/or dotnetdesktop7 using the 7th Heaven installer. Thanks to [infirit](https://github.com/infirit) the cause for this has been discovered, and a fix has been applied.
* Some users with a native version of .NET installed on their system will have 7th Heaven try to load that instead of the .NET Desktop version installed in the proton prefix. 7thDeck will now unset the $DOTNET_ROOT variable and remove `/home/deck/dotnet` from $PATH when launching 7th Heaven. Some slight tweaking to this fix needs to be completed before this PR can be merged.
* ~~The detection of proton prefixes on the Steam Deck's SD card has been reworked to check all directories under `/run/media/deck/` instead of relying on the symlink at `/run/media/mmcblk0p1`. I am not sure how long Valve plans to keep the symlink there, but this change has been made in the interest of future proofing. This requires some testing before this PR can be merged.~~