### PR TITLE
Force Steam to Rebuild libraryfolders.vdf

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,16 @@ echo "#   or ask in the #Steamdeck-Proton channel of the Tsunamods Discord   #"
 echo "########################################################################"
 echo -e "\n"
 
+# Rebuild libraryfolders.vdf
+echo "Rebuilding libraryfolders.vdf. Steam will restart."
+pkill -9 steam
+while pgrep steam > /dev/null; do sleep 1; done
+rm $HOME/.steam/steam/steamapps/libraryfolders.vdf &>> "7thDeck.log"
+rm $HOME/.steam/steam/config/libraryfolders.vdf &>> "7thDeck.log"
+nohup steam &> /dev/null &
+sleep 5
+while ! pgrep steam > /dev/null; do sleep 1; done
+echo
 
 # Check for Proton 7
 echo -n "Checking if Proton 7 is installed... "


### PR DESCRIPTION
This will force Steam to rebuild the `libraryfolders.vdf` when the install script is run, which should avoid the issues where the script fails to detect Proton/SLR/FF7 because the `libraryfolders.vdf` is stale.

I'm not sure what causes this but it seems to be an incredibly common behaviour for Steam to just not update these files, even immediately after installing a game or tool.

Need to have someone test this branch before I can complete the merge.