### PR TITLE
Sanitize WINEPATH before deleting anything

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -70,7 +70,7 @@ cp ${XDG_DATA_HOME}/Steam/config/config.vdf ${XDG_DATA_HOME}/Steam/config/config
 perl -0777 -i -pe 's/"CompatToolMapping"\n\s+{/"CompatToolMapping"\n\t\t\t\t{\n\t\t\t\t\t"39140"\n\t\t\t\t\t{\n\t\t\t\t\t\t"name"\t\t"proton_7"\n\t\t\t\t\t\t"config"\t\t""\n\t\t\t\t\t\t"priority"\t\t"250"\n\t\t\t\t\t}/gs' \
 ${XDG_DATA_HOME}/Steam/config/config.vdf
 while pgrep "steam" > /dev/null; do sleep 1; done
-rm -rf "${WINEPATH%/pfx}"/*
+[ "${WINEPATH}" = */compatdata/39140/pfx ] && rm -rf "${WINEPATH%/pfx}"/*
 echo "Sign into the Steam account that owns FF7 if prompted."
 nohup steam steam://rungameid/39140 &> /dev/null &
 echo "Waiting for Steam..."


### PR DESCRIPTION
This should prevent https://github.com/dotaxis/7thDeck/issues/32 from happening if somehow the script continues without detecting FF7's prefix location.

This should be unreachable code without WINEPATH being set, but it should be sanitized anyway.