### PR TITLE
Fix Hanging on Steam Kill and Lag in Game Mode

### DIFF
--- a/deps/7th Heaven.sh
+++ b/deps/7th Heaven.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 . functions.sh
 
+IS_GAMESCOPE=$(pgrep gamescope > /dev/null && echo true || echo false)
+if [ $IS_GAMESCOPE = true ]; then
+  echo "d3d9.shaderModel = 1" > dxvk.conf
+else
+  [ -f "dxvk.conf" ] && rm dxvk.conf
+fi
+
 IS_STEAMOS=@STEAMOS@
 if [ $IS_STEAMOS = true ] ; then
   export STEAM_COMPAT_DATA_PATH=${HOME}/.steam/steam/steamapps/compatdata/39140

--- a/install.sh
+++ b/install.sh
@@ -96,12 +96,14 @@ export STEAM_COMPAT_MOUNTS="$(getSteamLibrary 2805730):$(getSteamLibrary 1628350
 
 # Force FF7 under Proton 9
 echo "Rebuilding Final Fantasy VII under Proton 9..."
-echo "If the script hangs here, please exit Steam manually."
-killall -9 steam
+echo "The script may ask for your root password. This is to kill the Steam process."
+while pgrep "steam" > /dev/null; do
+  sudo pkill -9 steam
+  sleep 1
+done
 cp ${XDG_DATA_HOME}/Steam/config/config.vdf ${XDG_DATA_HOME}/Steam/config/config.vdf.bak
 perl -0777 -i -pe 's/"CompatToolMapping"\n\s+{/"CompatToolMapping"\n\t\t\t\t{\n\t\t\t\t\t"39140"\n\t\t\t\t\t{\n\t\t\t\t\t\t"name"\t\t"proton_9"\n\t\t\t\t\t\t"config"\t\t""\n\t\t\t\t\t\t"priority"\t\t"250"\n\t\t\t\t\t}/gs' \
 ${XDG_DATA_HOME}/Steam/config/config.vdf
-while pgrep "steam" > /dev/null; do sleep 1; done
 [ "${WINEPATH}" = */compatdata/39140/pfx ] && rm -rf "${WINEPATH%/pfx}"/*
 echo "Sign into the Steam account that owns FF7 if prompted."
 nohup steam steam://rungameid/39140 &> /dev/null &


### PR DESCRIPTION
* [Steam Deck] Removing `dxvk.conf` fixed crashing in Desktop Mode, but introduced graphical issues and lag in Game Mode. We will now check if gamescope is running and add/remove `dxvk.conf` depending on that result. We can somewhat safely assume we are in game mode if the result of `pgrep gamescope` is not null, but we may have to revisit this later on.
* Widespread issues of getting stuck on the "Rebuilding Final Fantasy VII under Proton 9..." step seem to be caused by Steam getting launched with higher privileges than us. I did my best to avoid this, but running the 7thDeck installer now requires a root password to be set so we can kill steam with `sudo`.