### PR TITLE
Update functions and install for flatpak steam installation

### DIFF
--- a/deps/functions.sh
+++ b/deps/functions.sh
@@ -12,24 +12,24 @@ getSteamLibrary() {
   fi
 
   local path=$(
-       awk -v app_id="$app_id" '
-         /^[[:space:]]*"[0-9]+"$/ {
-           in_block = 1;
-           block = $0;
-           next;
-         }
-         in_block {
-           block = block "\n" $0;
-           if ($0 ~ /^\s*}/) {
-             in_block = 0;
-             if (block ~ app_id) {
-               match(block, /"path"\s+"([^"]+)"/, arr);
-               print arr[1];
-               exit;
-             }
-           }
-         }
-       '  "${steam_path}/steamapps/libraryfolders.vdf"
+    awk -v app_id="$app_id" '
+      /^[[:space:]]*"[0-9]+"$/ {
+        in_block = 1;
+        block = $0;
+        next;
+      }
+      in_block {
+        block = block "\n" $0;
+        if ($0 ~ /^\s*}/) {
+          in_block = 0;
+          if (block ~ app_id) {
+            match(block, /"path"\s+"([^"]+)"/, arr);
+            print arr[1];
+            exit;
+          }
+        }
+      }
+    ' "${steam_path}/steamapps/libraryfolders.vdf"
   )
 
   echo "$path"

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,30 @@ else
   IS_FLATPAK=true
   STEAMROOT="$HOME/.var/app/com.valvesoftware.Steam/.local/share/Steam"
 fi
+
+if [ "$(command -v steam)" != "" ] && [ "$IS_FLATPAK" = "true" ]; then
+  echo "Both a flatpak and regular steam install has been detected. "
+  while true; do
+      echo "Please press 1 to continue with flatpak installation or press 2 for regular steam: "
+      read -p "" input
+      if [[ $input != "1" && $input != "2" ]]; then
+          continue
+      fi
+      case $input in
+          1)
+              echo "Proceeding with Flatpak Steam installation"
+              break;;
+          2)
+              echo "Proceeding with Steam installation"
+              IS_FLATPAK=false;
+              STEAMROOT=$(readlink -f "$HOME/.steam/root")
+              break;;
+          *)
+              continue;;
+      esac
+  done
+fi
+
 echo "" > "7thDeck.log"
 exec > >(tee -ia "7thDeck.log") 2>&1
 

--- a/install.sh
+++ b/install.sh
@@ -5,19 +5,35 @@ XDG_DATA_HOME="${XDG_DATA_HOME:=${HOME}/.local/share}"
 IS_STEAMOS=$(grep -qi "SteamOS" /etc/os-release && echo true || echo false)
 IS_FLATPAK=false
 STEAMROOT=$(readlink -f "$HOME/.steam/root")
+echo "" > "7thDeck.log"
+exec > >(tee -ia "7thDeck.log") 2>&1
 
+echo "########################################################################"
+echo "#                             7thDeck v2.4                             #"
+echo "########################################################################"
+echo "#    This script will:                                                 #"
+echo "#   1. Apply patches to FF7's proton prefix to accomodate 7th Heaven   #"
+echo "#   2. Install 7th Heaven to a folder of your choosing                 #"
+echo "#   3. Add 7th Heaven to Steam using a custom launcher script          #"
+echo "#   4. Add a custom controller config for Steam Deck, to allow mouse   #"
+echo "#      control with trackpad without holding down the STEAM button     #"
+echo "########################################################################"
+echo "#           For support, please open an issue on GitHub,               #"
+echo "#      or ask in the #ff7-linux channel of the Tsunamods Discord       #"
+echo "########################################################################"
+echo -e "\n"
 if ! $(flatpak list --app | grep -q Steam && echo true || echo false); then
-  echo "Steam is not installed via Flatpak."
+  echo "Steam is not installed via Flatpak." &>> "7thDeck.log"
 else
-  echo "Steam is installed via Flatpak."
+  echo "Steam is installed via Flatpak." &>> "7thDeck.log"
   IS_FLATPAK=true
   STEAMROOT="$HOME/.var/app/com.valvesoftware.Steam/.local/share/Steam"
 fi
 
 if [ "$(command -v steam)" != "" ] && [ "$IS_FLATPAK" = "true" ]; then
-  echo "Both a flatpak and regular steam install has been detected. "
+  echo "Both a flatpak and regular steam install has been detected."
   while true; do
-      echo "Please press 1 to continue with flatpak installation or press 2 for regular steam: "
+      echo "Please press 1 to continue with flatpak installation or press 2 for regular Steam: "
       read -p "" input
       if [[ $input != "1" && $input != "2" ]]; then
           continue
@@ -36,25 +52,6 @@ if [ "$(command -v steam)" != "" ] && [ "$IS_FLATPAK" = "true" ]; then
       esac
   done
 fi
-
-echo "" > "7thDeck.log"
-exec > >(tee -ia "7thDeck.log") 2>&1
-
-echo "########################################################################"
-echo "#                             7thDeck v2.4                             #"
-echo "########################################################################"
-echo "#    This script will:                                                 #"
-echo "#   1. Apply patches to FF7's proton prefix to accomodate 7th Heaven   #"
-echo "#   2. Install 7th Heaven to a folder of your choosing                 #"
-echo "#   3. Add 7th Heaven to Steam using a custom launcher script          #"
-echo "#   4. Add a custom controller config for Steam Deck, to allow mouse   #"
-echo "#      control with trackpad without holding down the STEAM button     #"
-echo "########################################################################"
-echo "#           For support, please open an issue on GitHub,               #"
-echo "#      or ask in the #ff7-linux channel of the Tsunamods Discord       #"
-echo "########################################################################"
-echo -e "\n"
-
 # Check for Proton
 while true; do
   if ! pgrep steam > /dev/null; then nohup steam &> /dev/null; fi
@@ -133,11 +130,9 @@ while pidof "steam" > /dev/null; do
   killall -9 steam &>> "7thDeck.log"
   sleep 1
 done
-
 cp $STEAMROOT/config/config.vdf $STEAMROOT/config/config.vdf.bak
 perl -0777 -i -pe 's/"CompatToolMapping"\n\s+{/"CompatToolMapping"\n\t\t\t\t{\n\t\t\t\t\t"39140"\n\t\t\t\t\t{\n\t\t\t\t\t\t"name"\t\t"proton_9"\n\t\t\t\t\t\t"config"\t\t""\n\t\t\t\t\t\t"priority"\t\t"250"\n\t\t\t\t\t}/gs' \
 $STEAMROOT/config/config.vdf
-
 [ "${WINEPATH}" = */compatdata/39140/pfx ] && rm -rf "${WINEPATH%/pfx}"/*
 echo "Sign into the Steam account that owns FF7 if prompted."
 if [ $IS_FLATPAK = true ]; then

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,16 @@
 XDG_DESKTOP_DIR=$(xdg-user-dir DESKTOP)
 XDG_DATA_HOME="${XDG_DATA_HOME:=${HOME}/.local/share}"
 IS_STEAMOS=$(grep -qi "SteamOS" /etc/os-release && echo true || echo false)
+IS_FLATPAK=false
+STEAMROOT=$(echo $HOME/.steam/steam)
 
+if ! $(flatpak list --app | grep -q Steam && echo true || echo false); then
+  echo "Steam is not installed via Flatpak."
+else
+  echo "Steam is installed via Flatpak."
+  IS_FLATPAK=true
+  STEAMROOT=$(echo $HOME/.var/app/com.valvesoftware.Steam/.local/share/Steam)
+fi
 echo "" > "7thDeck.log"
 exec > >(tee -ia "7thDeck.log") 2>&1
 
@@ -26,7 +35,9 @@ echo -e "\n"
 while true; do
   if ! pgrep steam > /dev/null; then nohup steam &> /dev/null; fi
   while ! pgrep steam > /dev/null; do sleep 1; done
+  echo -n "Steam running"
   PROTON=$(LIBRARY=$(getSteamLibrary 2805730) && [ -n "$LIBRARY" ] && echo "$LIBRARY/steamapps/common/Proton 9.0 (Beta)/proton" || echo "NONE")
+  echo -n "Library $LIBRARY"
   echo -n "Checking if Proton 9 is installed... "
   if [ "$PROTON" = "NONE" ]; then
     echo -e "\nNot found! Launching Steam to install."
@@ -34,8 +45,8 @@ while true; do
     read -p "Press Enter when Proton 9 is done installing."
     killall -9 steam
     while pgrep steam >/dev/null; do sleep 1; done
-    rm $HOME/.steam/steam/steamapps/libraryfolders.vdf &>> "7thDeck.log"
-    rm $HOME/.steam/steam/config/libraryfolders.vdf &>> "7thDeck.log"
+    rm $STEAMROOT/steamapps/libraryfolders.vdf &>> "7thDeck.log"
+    rm $STEAMROOT/config/libraryfolders.vdf &>> "7thDeck.log"
   else
     echo "OK!"
     echo "Found Proton at $PROTON!"
@@ -56,8 +67,8 @@ while true; do
     read -p "Press Enter when Steam Linux Runtime 3.0 (sniper) is done installing."
     killall -9 steam
     while pgrep steam >/dev/null; do sleep 1; done
-    rm $HOME/.steam/steam/steamapps/libraryfolders.vdf &>> "7thDeck.log"
-    rm $HOME/.steam/steam/config/libraryfolders.vdf &>> "7thDeck.log"
+    rm $STEAMROOT/steamapps/libraryfolders.vdf &>> "7thDeck.log"
+    rm $STEAMROOT/config/libraryfolders.vdf &>> "7thDeck.log"
   else
     echo "OK!"
     echo "Found SLR at $RUNTIME!"
@@ -78,8 +89,8 @@ while true; do
     read -p "Press Enter when FINAL FANTASY VII is done installing."
     killall -9 steam
     while pgrep steam > /dev/null; do sleep 1; done
-    rm $HOME/.steam/steam/steamapps/libraryfolders.vdf &>> "7thDeck.log"
-    rm $HOME/.steam/steam/config/libraryfolders.vdf &>> "7thDeck.log"
+    rm $STEAMROOT/steamapps/libraryfolders.vdf &>> "7thDeck.log"
+    rm $STEAMROOT/config/libraryfolders.vdf &>> "7thDeck.log"
   else
     echo "OK!"
     echo "Found FF7 at $FF7_LIBRARY!"
@@ -100,16 +111,29 @@ while pidof "steam" > /dev/null; do
   killall -9 steam &>> "7thDeck.log"
   sleep 1
 done
-cp $HOME/.steam/steam/config/config.vdf $HOME/.steam/steam/config/config.vdf.bak
-perl -0777 -i -pe 's/"CompatToolMapping"\n\s+{/"CompatToolMapping"\n\t\t\t\t{\n\t\t\t\t\t"39140"\n\t\t\t\t\t{\n\t\t\t\t\t\t"name"\t\t"proton_9"\n\t\t\t\t\t\t"config"\t\t""\n\t\t\t\t\t\t"priority"\t\t"250"\n\t\t\t\t\t}/gs' \
-$HOME/.steam/steam/config/config.vdf
+
+if [ $IS_FLATPAK = true ]; then
+  cp $STEAMROOT/config/config.vdf $STEAMROOT/config/config.vdf.bak
+   perl -0777 -i -pe 's/"CompatToolMapping"\n\s+{/"CompatToolMapping"\n\t\t\t\t{\n\t\t\t\t\t"39140"\n\t\t\t\t\t{\n\t\t\t\t\t\t"name"\t\t"proton_9"\n\t\t\t\t\t\t"config"\t\t""\n\t\t\t\t\t\t"priority"\t\t"250"\n\t\t\t\t\t}/gs' \
+    $STEAMROOT/config/config.vdf
+else
+  cp $STEAMROOT/config/config.vdf $STEAMROOT/config/config.vdf.bak
+  perl -0777 -i -pe 's/"CompatToolMapping"\n\s+{/"CompatToolMapping"\n\t\t\t\t{\n\t\t\t\t\t"39140"\n\t\t\t\t\t{\n\t\t\t\t\t\t"name"\t\t"proton_9"\n\t\t\t\t\t\t"config"\t\t""\n\t\t\t\t\t\t"priority"\t\t"250"\n\t\t\t\t\t}/gs' \
+  $STEAMROOT/config/config.vdf
+fi
+
 [ "${WINEPATH}" = */compatdata/39140/pfx ] && rm -rf "${WINEPATH%/pfx}"/*
 echo "Sign into the Steam account that owns FF7 if prompted."
-nohup steam steam://rungameid/39140 &> /dev/null &
-echo "Waiting for Steam..."
-while ! pgrep "FF7_Launcher" > /dev/null; do sleep 1; done
-killall -9 "FF7_Launcher.exe"
-echo
+if [ $IS_FLATPAK = true ]; then
+  input "Please run FF7 on steam and then press enter to continue:"
+else
+  nohup steam steam://rungameid/39140 &> /dev/null &
+  echo "Waiting for Steam..."
+  while ! pgrep "FF7_Launcher" > /dev/null; do sleep 1; done
+  killall -9 "FF7_Launcher.exe"
+  echo
+fi
+
 
 # Fix infinite loop on "Verifying installed game is compatible"
 [ -L "$FF7_DIR/FINAL FANTASY VII" ] && unlink "$FF7_DIR/FINAL FANTASY VII"
@@ -133,11 +157,13 @@ echo "Downloading 7th Heaven..."
 downloadDependency "tsunamods-codes/7th-Heaven" "*.exe" SEVENTH_INSTALLER
 echo
 
+
+
 # Install 7th Heaven using EXE
 echo "Installing 7th Heaven..."
 mkdir -p "${WINEPATH}/drive_c/ProgramData" # fix vcredist install - infirit
 STEAM_COMPAT_APP_ID=39140 STEAM_COMPAT_DATA_PATH="${WINEPATH%/pfx}" \
-STEAM_COMPAT_CLIENT_INSTALL_PATH=$(readlink -f "$HOME/.steam/steam") \
+STEAM_COMPAT_CLIENT_INSTALL_PATH=$(readlink -f "$STEAMROOT") \
 "$RUNTIME" -- "$PROTON" waitforexitandrun \
 "$SEVENTH_INSTALLER" /VERYSILENT /DIR="Z:$INSTALL_PATH" /LOG="7thHeaven.log" &>> "7thDeck.log"
 echo
@@ -157,6 +183,7 @@ echo
 
 # Tweaks to game
 echo "Applying patches to FF7..."
+
 cp -f "deps/timeout.exe" "$WINEPATH/drive_c/windows/system32/"
 echo "FF7DISC1" > "$WINEPATH/drive_c/.windows-label"
 echo "44000000" > "$WINEPATH/drive_c/.windows-serial"
@@ -187,8 +214,8 @@ if [ $IS_STEAMOS = true ]; then
 
   # This allows moving and clicking the mouse by using the right track-pad without holding down the STEAM button
   echo "Adding controller config..."
-  cp -f deps/controller_neptune_gamepad+mouse+click.vdf ${HOME}/.steam/steam/controller_base/templates/controller_neptune_gamepad+mouse+click.vdf
-  for CONTROLLERCONFIG in ${HOME}/.steam/steam/steamapps/common/Steam\ Controller\ Configs/*/config/configset_controller_neptune.vdf ; do
+  cp -f deps/controller_neptune_gamepad+mouse+click.vdf $STEAMROOT/controller_base/templates/controller_neptune_gamepad+mouse+click.vdf
+  for CONTROLLERCONFIG in $STEAMROOT/steamapps/common/Steam\ Controller\ Configs/*/config/configset_controller_neptune.vdf ; do
     if grep -q "\"39140\"" "$CONTROLLERCONFIG"; then
       perl -0777 -i -pe 's/"39140"\n\s+\{\n\s+"template"\s+"controller_neptune_gamepad_fps.vdf"\n\s+\}/"39140"\n\t\{\n\t\t"template"\t\t"controller_neptune_gamepad+mouse+click.vdf"\n\t\}\n\t"7th heaven"\n\t\{\n\t\t"template"\t\t"controller_neptune_gamepad+mouse+click.vdf"\n\t\}/gs' "$CONTROLLERCONFIG"
     else


### PR DESCRIPTION
Came across this issue when trying to install 7th Heaven on my Fedora machine with Flatpak steam only.

Running the script with the Flatpak version of steam causes it not to install and fail. I've updated the getSteamLibrary function and install script to accomodate. I have tested flatpak and non flatpak 7th heaven installs and they work as intended. Flatpak has some caveats, I could not get it to automatically as a non-steam game and to get it to automatically start FF7 to generate the prefix (and then kill it). The user can add the game via GUI method in steam.

Image is running via 7th heaven with flatpak only steam
![Flatpak](https://github.com/user-attachments/assets/592380dc-5f1c-43ed-a2a3-df411bd15017)
